### PR TITLE
Setting user agent header for cURL requests 

### DIFF
--- a/Envato_marketplaces.php
+++ b/Envato_marketplaces.php
@@ -400,6 +400,7 @@ class Envato_marketplaces {
 
       $ch = curl_init($url);
       curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+      curl_setopt($ch,CURLOPT_USERAGENT,'Mozilla/5.0 (compatible; Envato Marketplace API Wrapper PHP)');
 
       $data = curl_exec($ch);
       curl_close($ch);


### PR DESCRIPTION
Hello,

according to Envato API rules (http://marketplace.envato.com/api/documentation), all requests to API should have set proper User Agent header. This patch fixes this issue.

Thanks,
Michal
